### PR TITLE
Improved nginx options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,14 @@ Example configuration:
 
 ```nix
 {
-  services.authentik = {
-    # other authentik options as in the example configuration at the top
-    nginx = {
-      enable = true;
-      enableACME = true;
-      host = "auth.example.com";
+  services = {
+    authentik = {
+      # other authentik options as in the example configuration at the top
+      nginx = {
+        enable = true;
+        host = "auth.example.com";
+        vhost.enableACME = true;
+      };
     };
   };
 }


### PR DESCRIPTION
Added support for configuration nginx `vhost` directly in authentic without the need to add a separate entry in the nginx service. I've also added support for using wildcard/multiple domain certificates when using `useACMEHost`.

Breaking Changes:
- `forceSSL` is not automatic set anymore if `enableACME` is set
- `recommendedTlsSettings` inside the nginx service is not being automatically set anymore if `enableACME` is set

Future PRs:
- I am currently evaluating if the proxy pass is needed to happen to the https port 9443 or if 9000 on http would be sufficient
- I am also willing to upgrade this to 23.11 and therefor update postgres deprecations
- Improvements/cleanup regarding package builds