### PR TITLE
link static workdir deps to /run/authentik

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -154,6 +154,9 @@ in
           requiredBy = [ "authentik.service" ];
           before = [ "authentik.service" ];
           restartTriggers = [ config.environment.etc."authentik/config.yml".source ];
+          preStart = ''
+            ln -svf ${config.services.authentik.authentikComponents.staticWorkdirDeps}/* /run/authentik/
+          '';
           serviceConfig = {
             RuntimeDirectory = "authentik";
             WorkingDirectory = "%t/authentik";


### PR DESCRIPTION
Fix for #6 

This links the authentik workdir dependencies to /run/authentik.
This resolves the issue that emails can't be send because of missing assets.

Thanks to @xanderio for providing this fix.