### PR TITLE
authentik-ldap: restart on failure

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -231,6 +231,7 @@ in
           DynamicUser = true;
           ExecStart = "${config.services.authentik.authentikComponents.gopkgs}/bin/ldap";
           EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+          Restart = "on-failure";
         };
       };
     }))


### PR DESCRIPTION
I'm occasionally seeing the following error:

    Jan 01 22:02:10 auth ldap[151813]: fatal error: concurrent map writes
    Jan 01 22:02:10 auth ldap[151813]: fatal error: concurrent map writes
    Jan 01 22:02:10 auth ldap[151813]: goroutine 4841 [running]:
    Jan 01 22:02:10 auth ldap[151813]: goauthentik.io/api/v3.(*Configuration).AddDefaultHeader(...)
    Jan 01 22:02:10 auth ldap[151813]:         goauthentik.io/api/v3@v3.2023101.1/configuration.go:120
    Jan 01 22:02:10 auth ldap[151813]: goauthentik.io/internal/outpost/ldap/search/direct.(*DirectSearcher).Search(0xc0002ba4f8, 0xc000510dd0)
    Jan 01 22:02:10 auth ldap[151813]:         goauthentik.io/internal/outpost/ldap/search/direct/direct.go:112 +0x65a
    [...]
    Jan 01 22:02:10 auth systemd[1]: authentik-ldap.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
    Jan 01 22:02:10 auth systemd[1]: authentik-ldap.service: Failed with result 'exit-code'.

Obviously, I need to find out what's up there. However, services shouldn't just die on a crash, but restart in that case. If that happens too often, StartLimitBurst/StartLimitIntervalSec ensure that the (re)start attempt is aborted eventually.

This is especially problematic because Nextcloud tries to contact the LDAP server on every single request for a sync which means that the entire service is down when such a crash happens.