### PR TITLE
enable media uploads

### DIFF
--- a/components/authentik_media_upload.patch
+++ b/components/authentik_media_upload.patch
@@ -1,0 +1,12 @@
+diff --git a/authentik/api/v3/config.py b/authentik/api/v3/config.py
+--- a/authentik/api/v3/config.py
++++ b/authentik/api/v3/config.py
+@@ -66,7 +66,7 @@ class ConfigView(APIView):
+         """Get all capabilities this server instance supports"""
+         caps = []
+         deb_test = settings.DEBUG or settings.TEST
+-        if Path(settings.MEDIA_ROOT).is_mount() or deb_test:
++        if Path(settings.MEDIA_ROOT).is_mount() or CONFIG.get_bool("media.enable_upload") or deb_test:
+             caps.append(Capabilities.CAN_SAVE_MEDIA)
+         if GEOIP_READER.enabled:
+             caps.append(Capabilities.CAN_GEO_IP)

--- a/components/staticWorkdirDeps.nix
+++ b/components/staticWorkdirDeps.nix
@@ -1,10 +1,17 @@
 { authentik-src
 , authentikComponents
 , linkFarm
+, applyPatches
 }:
-
+let
+  patched-src = applyPatches { 
+    src = authentik-src;
+    name = "patched-authentik-source";
+    patches = [ ./authentik_media_upload.patch ];
+  };
+in
 linkFarm "authentik-static-workdir-deps" [
-  { name = "authentik"; path = "${authentik-src}/authentik"; }
+  { name = "authentik"; path = "${patched-src}/authentik"; }
   { name = "locale"; path = "${authentik-src}/locale"; }
   { name = "blueprints"; path = "${authentik-src}/blueprints"; }
   { name = "internal"; path = "${authentik-src}/internal"; }

--- a/module.nix
+++ b/module.nix
@@ -114,6 +114,8 @@ in
             host = mkDefault "";
           };
           cert_discovery_dir = mkIf (cfg.nginx.enable && cfg.nginx.enableACME) "env://CREDENTIALS_DIRECTORY";
+          paths.media = mkDefault "/var/lib/authentik/media";
+          media.enable_upload = mkDefault true;
         };
         redis.servers.authentik = {
           enable = true;
@@ -181,6 +183,7 @@ in
           restartTriggers = [ config.environment.etc."authentik/config.yml".source ];
           preStart = ''
             ln -svf ${cfg.authentikComponents.staticWorkdirDeps}/* /var/lib/authentik/
+            mkdir -p ${cfg.settings.paths.media}
           '';
           serviceConfig = {
             Environment = [


### PR DESCRIPTION
The media upload feature is build around being deployed in a container and only enables uploads when `/media` is a mountpoint. This isn't the case on nixos and as such media uploads are disable.

In order to enable this, we need to patch authentik so that the `can_save_media` capability is enabled.

Fixes: #8 