### PR TITLE
Reduce NixOS config overrides

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -261,12 +261,6 @@ in
           '';
           environment.TZ = tz;
           serviceConfig = mkMerge [ serviceDefaults {
-            Environment = [
-              "AUTHENTIK_ERROR_REPORTING__ENABLED=false"
-              "AUTHENTIK_DISABLE_UPDATE_CHECK=true"
-              "AUTHENTIK_DISABLE_STARTUP_ANALYTICS=true"
-              "AUTHENTIK_AVATARS=initials"
-            ];
             StateDirectory = "authentik";
             UMask = "0027";
             # TODO /run might be sufficient

--- a/module.nix
+++ b/module.nix
@@ -184,7 +184,7 @@ in
         };
         postgresql = mkIf cfg.createDatabase {
           enable = true;
-          package = pkgs.postgresql_14;
+          package = lib.mkDefault pkgs.postgresql_14;
           ensureDatabases = [ "authentik" ];
           ensureUsers = [
             { name = "authentik"; ensureDBOwnership = true; }


### PR DESCRIPTION
This eliminates two things that can cause conflicts with other NixOS configuration:

`services.postgresql.package` is set to PostgreSQL 14 with `lib.mkDefault`, so the user can override it. (I'm not sure why this was there at all - Authentik seems to run just fine with PostgreSQL 15.)

`time.timeZone` is no longer set. Instead, Authentik services are launched with the `TZ` environment variable set.

AFAICT Authentik is working fine for me with both of these changes.