### PR TITLE
ordering authentik after network is configured

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -207,7 +207,8 @@ in
         authentik-migrate = {
           requiredBy = [ "authentik.service" ];
           requires = lib.optionals cfg.createDatabase [ "postgresql.service" ];
-          after = lib.optionals cfg.createDatabase [ "postgresql.service" ];
+          wants = [ "network-online.target" ];
+          after = [ "network-online.target" ] ++ lib.optionals cfg.createDatabase [ "postgresql.service" ];
           before = [ "authentik.service" ];
           restartTriggers = [ config.environment.etc."authentik/config.yml".source ];
           serviceConfig = mkMerge [ serviceDefaults {
@@ -219,6 +220,8 @@ in
         };
         authentik-worker = {
           requiredBy = [ "authentik.service" ];
+          wants = [ "network-online.target" ];
+          after = [ "network-online.target" ];
           before = [ "authentik.service" ];
           restartTriggers = [ config.environment.etc."authentik/config.yml".source ];
           preStart = ''


### PR DESCRIPTION
In systems that don't support the "online" concept or just disable it, the dependency of `network-online.target` is basically ignored. Therefore, I've added a dependency to `network.target` to ensure services are started after the network is configured.