### PR TITLE
module: fix media root config

### DIFF
--- a/components/authentik_media_tenant_files_miration.patch
+++ b/components/authentik_media_tenant_files_miration.patch
@@ -9,7 +9,7 @@ index 40795d460..7ac1efb34 100644
 +from authentik.lib.config import CONFIG
  
 -MEDIA_ROOT = Path(__file__).parent.parent.parent / "media"
-+MEDIA_ROOT = Path(CONFIG.get("paths.media"))
++MEDIA_ROOT = Path(CONFIG.get("storage.media.file.path"))
  TENANT_MEDIA_ROOT = MEDIA_ROOT / "public"
  
  


### PR DESCRIPTION
Was changed within upstream commit abc0c2d2a2a0bfb0214798ed6bca9d59359b39f8.

The sole reason this worked was that `settings.storage.media.file.path` pointed to `./media`, relative to `/var/lib/authentik`.

Update our config accordingly.

cc @xanderio @WilliButz 