### PR TITLE
components/gopkgs: skip tests

### DIFF
--- a/components/gopkgs.nix
+++ b/components/gopkgs.nix
@@ -43,6 +43,7 @@ buildGo122Module {
   ];
   vendorHash = "sha256-YpOG5pNw5CNSubm1OkPVpSi7l+l5UdJFido2SQLtK3g=";
   nativeBuildInputs = [ makeWrapper ];
+  doCheck = false;
   postInstall = ''
     wrapProgram $out/bin/server --prefix PATH : ${authentikComponents.pythonEnv}/bin
     wrapProgram $out/bin/server --prefix PYTHONPATH : ${authentikComponents.staticWorkdirDeps}


### PR DESCRIPTION
There aren't any tests, but it's hanging in this phase for a while since it compiles Go code to see if there are any tests in the modules.

    authentik-gopkgs> Running phase: checkPhase
    authentik-gopkgs> ?     goauthentik.io/cmd/ldap [no test files]
    authentik-gopkgs> ?     goauthentik.io/cmd/server       [no test files]
    authentik-gopkgs> ?     goauthentik.io/cmd/proxy        [no test files]
    authentik-gopkgs> ?     goauthentik.io/cmd/radius       [no test files]

cc @WilliButz 