### PR TITLE
Allow applying additional patches

### DIFF
--- a/components/default.nix
+++ b/components/default.nix
@@ -11,28 +11,24 @@
 pkgs.lib.makeScope pkgs.newScope (final:
   let
     docs = final.callPackage ./docs.nix {
-      inherit authentik-src authentik-version buildNapalmPackage;
+      inherit authentik-version buildNapalmPackage;
     };
     frontend = final.callPackage ./frontend.nix {
-      inherit authentik-src authentik-version buildNapalmPackage;
+      inherit authentik-version buildNapalmPackage;
     };
     pythonEnv = final.callPackage ./pythonEnv.nix {
-      inherit authentik-src mkPoetryEnv defaultPoetryOverrides authentikPoetryOverrides;
+      inherit mkPoetryEnv defaultPoetryOverrides authentikPoetryOverrides;
     };
     # server + outposts
     gopkgs = final.callPackage ./gopkgs.nix {
-      inherit authentik-src authentik-version;
+      inherit authentik-version;
     };
     staticWorkdirDeps = final.callPackage ./staticWorkdirDeps.nix {
-      inherit authentik-src;
       inherit extraPatches;
     };
-    migrate = final.callPackage ./migrate.nix {
-      inherit authentik-src;
-    };
+    migrate = final.callPackage ./migrate.nix { };
     # worker
-    manage = final.callPackage ./manage.nix {
-    };
+    manage = final.callPackage ./manage.nix { };
   in
   {
     authentikComponents = {

--- a/components/default.nix
+++ b/components/default.nix
@@ -5,6 +5,7 @@
 , defaultPoetryOverrides
 , mkPoetryEnv
 , pkgs
+, extraPatches ? []
 }:
 
 pkgs.lib.makeScope pkgs.newScope (final:
@@ -24,6 +25,7 @@ pkgs.lib.makeScope pkgs.newScope (final:
     };
     staticWorkdirDeps = final.callPackage ./staticWorkdirDeps.nix {
       inherit authentik-src;
+      inherit extraPatches;
     };
     migrate = final.callPackage ./migrate.nix {
       inherit authentik-src;

--- a/components/staticWorkdirDeps.nix
+++ b/components/staticWorkdirDeps.nix
@@ -2,6 +2,7 @@
 , authentikComponents
 , linkFarm
 , applyPatches
+, extraPatches ? []
 }:
 let
   patched-src = applyPatches {
@@ -10,7 +11,7 @@ let
     patches = [
       ./authentik_media_upload.patch
       ./authentik_media_tenant_files_miration.patch
-    ];
+    ] ++ extraPatches;
   };
 in
 linkFarm "authentik-static-workdir-deps" [

--- a/flake.nix
+++ b/flake.nix
@@ -74,10 +74,11 @@
           mkPoetryEnv ? (import inputs.poetry2nix { inherit pkgs; }).mkPoetryEnv,
           defaultPoetryOverrides ? (import inputs.poetry2nix { inherit pkgs; }).defaultPoetryOverrides,
           authentikPoetryOverrides ? import ./poetry2nix-python-overrides.nix pkgs,
-          buildNapalmPackage ? napalm.legacyPackages.${system}.buildPackage
+          buildNapalmPackage ? napalm.legacyPackages.${system}.buildPackage,
+          extraPatches ? []
         }:
           import ./components {
-            inherit pkgs authentik-src authentik-version mkPoetryEnv defaultPoetryOverrides authentikPoetryOverrides buildNapalmPackage;
+            inherit extraPatches pkgs authentik-src authentik-version mkPoetryEnv defaultPoetryOverrides authentikPoetryOverrides buildNapalmPackage;
           };
       };
       perSystem = { pkgs, system, self', ... }: let


### PR DESCRIPTION
Not very pretty, but useful when having to apply local patches for the Python code. Can be done like this:

    (self: super: {
      inherit (authentik-nix.lib.mkAuthentikScope {
        pkgs = self;
        extraPatches = [
          ./hackhack.patch
        ];
      }) authentikComponents;
    })

This cannot be used currently for Go patches since I left it out for the gopkgs part intentionally due to the filterSource stuff since it's somewhat likely that a patch contains stuff that's filtered out by the `filterSource` expression. Not sure what to do about that.

cc @fpletz @WilliButz 