### PR TITLE
fixed nixos-24.05 compatibility

### DIFF
--- a/components/frontend.nix
+++ b/components/frontend.nix
@@ -2,12 +2,12 @@
 , authentik-version
 , authentikComponents
 , buildNapalmPackage
-, nodejs_21
+, nodejs_20
 }:
 buildNapalmPackage "${authentik-src}/web" rec {
   version = authentik-version; # 0.0.0 specified upstream in package.json
   NODE_ENV = "production";
-  nodejs = nodejs_21;
+  nodejs = nodejs_20;
   preBuild = ''
     ln -sv ${authentikComponents.docs} ../website
   '';


### PR DESCRIPTION
As Node.js 21 isn't a LTS release, it is not included in NixOS 24.05. 

Authentik itself builds against Node.js 20:
https://docs.goauthentik.io/developer-docs/setup/frontend-dev-environment

Node.js 21 is included in NixOS unstable and 24.05.