### PR TITLE
Fix indentation of markdown code blocks

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -85,9 +85,9 @@ in
           to the authentic documentation.
 
           ```
-            # example content
-            AUTHENTIK_SECRET_KEY=<secret key>
-            AUTHENTIK_EMAIL__PASSWORD=<smtp password>
+          # example content
+          AUTHENTIK_SECRET_KEY=<secret key>
+          AUTHENTIK_EMAIL__PASSWORD=<smtp password>
           ```
         '';
       };
@@ -109,8 +109,8 @@ in
           to the authentic documentation.
 
           ```
-            # example content
-            AUTHENTIK_TOKEN=<token from authentik for this outpost>
+          # example content
+          AUTHENTIK_TOKEN=<token from authentik for this outpost>
           ```
         '';
       };
@@ -132,8 +132,8 @@ in
           to the authentic documentation.
 
           ```
-            # example content
-            AUTHENTIK_TOKEN=<token from authentik for this outpost>
+          # example content
+          AUTHENTIK_TOKEN=<token from authentik for this outpost>
           ```
         '';
       };


### PR DESCRIPTION
Before they rendered like this 

![image](https://github.com/user-attachments/assets/75ed9a88-ba08-4bfd-9349-8806ac2ad741)
