### PR TITLE
Add NixOS support notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Nix flake providing a package, NixOS module and basic VM test for [authentik](https://github.com/goauthentik/authentik)
 
+## NixOS compatibilty
+
+This project only supports NixOS unstable.
+
 ## Important Note
 Please note that this project is not directly affiliated with the official [authentik](https://github.com/goauthentik/authentik) project. Most importantly this means that there is no official support for this packaging and deployment approach. Therefore, please refrain from opening issues for the official project when running into problems with this flake. Feel free to open issues here. If in doubt, please open an issue here first so we can make sure that it's not directly related to this packaging/deployment approach before escalating to the official project.
 


### PR DESCRIPTION
According to this comment, there is no indent to support stable NixOS. 
https://github.com/nix-community/authentik-nix/pull/51#issuecomment-2797197245