### PR TITLE
update: 2025.6.4 -> 2025.8.1

### DIFF
--- a/components/docs.nix
+++ b/components/docs.nix
@@ -13,8 +13,10 @@ buildNapalmPackage "${authentik-src}/website" {
     "cp -v ${authentik-src}/SECURITY.md ../SECURITY.md"
     "cp -vr ${authentik-src}/blueprints ../blueprints"
     "cp -v ${authentik-src}/schema.yml ../schema.yml"
-    "npm install --include=dev"
-    "npm run build-bundled"
+    "cp -v ${authentik-src}/docker-compose.yml ../docker-compose.yml"
+    "npm config set loglevel verbose"
+    "npm ci --workspaces --include-workspace-root --no-audit"
+    "npm run build"
   ];
   installPhase = ''
     rm -f ../website/static/blueprints

--- a/components/frontend.nix
+++ b/components/frontend.nix
@@ -17,8 +17,9 @@ buildNapalmPackage "${authentik-src}/web" rec {
   # from release build dependencies, therefore this workaround
   CHROMEDRIVER_SKIP_DOWNLOAD = "true";
   npmCommands = [
-    "npm install --include=dev --nodedir=${nodejs}/include/node --loglevel verbose"
+    "npm install --include=dev --nodedir=${nodejs}/include/node --loglevel verbose --ignore-scripts"
     "npm run build"
+    "npm run build:sfe"
   ];
   installPhase = ''
     mkdir $out

--- a/components/gopkgs.nix
+++ b/components/gopkgs.nix
@@ -42,7 +42,7 @@ buildGo124Module {
     "cmd/proxy"
     "cmd/radius"
   ];
-  vendorHash = "sha256-7oX7e7Ni5I6zblEQIeXjYOt4+QNSjH4Rpn7B5Cr5LMc=";
+  vendorHash = "sha256-wTTEDBRYCW1UFaeX49ufLT0c17sacJzcCaW/8cPNYR4=";
   nativeBuildInputs = [ makeWrapper ];
   doCheck = false;
   postInstall = ''

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "authentik-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1753187012,
-        "narHash": "sha256-bs/ThY3YixwBObahcS7BrOWj0gsaUXI664ldUQlJul8=",
+        "lastModified": 1755873658,
+        "narHash": "sha256-5l1g55b0xozGg0NaZFimiO5JbHGcudaNSEn1/XsweaU=",
         "owner": "goauthentik",
         "repo": "authentik",
-        "rev": "23ffad1c6be80bea223caf5f1cf265b984b76328",
+        "rev": "dd7c6b29d950664deadbcf5390272619a8bf9a5e",
         "type": "github"
       },
       "original": {
         "owner": "goauthentik",
-        "ref": "version/2025.6.4",
+        "ref": "version/2025.8.1",
         "repo": "authentik",
         "type": "github"
       }
@@ -38,11 +38,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750776420,
-        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "lastModified": 1756386758,
+        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749519371,
-        "narHash": "sha256-UJONN7mA2stweZCoRcry2aa1XTTBL0AfUOY84Lmqhos=",
+        "lastModified": 1756087852,
+        "narHash": "sha256-4jc3JDQt75fYXFrglgqyzF6C6zLU0QGLymzian4aP+U=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "7c06967eca687f3482624250428cc12f43c92523",
+        "rev": "6edb3ae27395cd88be3d64b732d1539957dad59c",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750499893,
-        "narHash": "sha256-ThKBd8XSvITAh2JqU7enOp8AfKeQgf9u7zYC41cnBE4=",
+        "lastModified": 1756395552,
+        "narHash": "sha256-5aJM14MpoLk2cdZAetu60OkLQrtFLWTICAyn1EP7ZpM=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "e824458bd917b44bf4c38795dea2650336b2f55d",
+        "rev": "030dffc235dcf240d918c651c78dc5f158067b51",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750987094,
-        "narHash": "sha256-GujDElxLgYatnNvuL1U6qd18lcuG6anJMjpfYRScV08=",
+        "lastModified": 1756466761,
+        "narHash": "sha256-ALXRHIMXQ4qVNfCbcWykC23MjMwUoHn9BreoBfqmq0Y=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "4b703d851b61e664a70238711a8ff0efa1aa2f52",
+        "rev": "0529e6d8227517205afcd1b37eee3088db745730",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
     };
     authentik-src = {
       # change version string in outputs as well when updating
-      url = "github:goauthentik/authentik/version/2025.6.4";
+      url = "github:goauthentik/authentik/version/2025.8.1";
       flake = false;
     };
   };
@@ -67,7 +67,7 @@
         ...
       }:
       let
-        authentik-version = "2025.6.4"; # to pass to the drvs of some components
+        authentik-version = "2025.8.1"; # to pass to the drvs of some components
       in
       {
         systems = import inputs.systems;

--- a/module.nix
+++ b/module.nix
@@ -185,10 +185,14 @@ in
         tz = "UTC";
 
         # Passed to each service and to the `ak` wrapper using `systemd-run(1)`
+        environment.PROMETHEUS_MULTIPROC_DIR = "%S/authentik/prometheus";
         serviceDefaults = {
           DynamicUser = true;
           User = "authentik";
           EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+          ExecStartPre = [
+            "${pkgs.coreutils}/bin/mkdir -p \${PROMETHEUS_MULTIPROC_DIR}"
+          ];
         };
         akOptions = flatten (
           mapAttrsToList
@@ -261,7 +265,7 @@ in
             after = [ "network-online.target" ] ++ lib.optionals cfg.createDatabase [ "postgresql.service" ];
             before = [ "authentik.service" ];
             restartTriggers = [ config.environment.etc."authentik/config.yml".source ];
-            environment.TZ = tz;
+            environment = mkMerge [ environment { TZ = tz; } ];
             serviceConfig = mkMerge [
               serviceDefaults
               {
@@ -289,13 +293,13 @@ in
             preStart = ''
               ln -svf ${config.services.authentik.authentikComponents.staticWorkdirDeps}/* /run/authentik/
             '';
-            environment.TZ = tz;
+            environment = mkMerge [ environment { TZ = tz; } ];
             serviceConfig = mkMerge [
               serviceDefaults
               {
                 RuntimeDirectory = "authentik";
                 WorkingDirectory = "%t/authentik";
-                ExecStart = "${cfg.authentikComponents.manage}/bin/manage.py worker";
+                ExecStart = "${cfg.authentikComponents.manage}/bin/manage.py worker --pid-file %t/authentik/worker.pid";
                 Restart = "on-failure";
                 RestartSec = "1s";
                 LoadCredential = mkIf (cfg.nginx.enable && cfg.nginx.enableACME) [
@@ -321,7 +325,7 @@ in
                 mkdir -p ${cfg.settings.storage.media.file.path}
               ''}
             '';
-            environment.TZ = tz;
+            environment = mkMerge [ environment { TZ = tz; } ];
             serviceConfig = mkMerge [
               serviceDefaults
               {


### PR DESCRIPTION
See https://next.goauthentik.io/releases/2025.8/
ChangeLog: https://next.goauthentik.io/releases/2025.8/#fixed-in-202581

The following things changed:

* We're blocked on going to NodeJS 24.x (which is the version upstream uses) because it breaks with napalm[1].

* The worker has been switched from celery to dramatiq. An automatic migration of the tasks doesn't exist, the operator must make sure to stop the server and let the queue drain[2].

  While this eliminates the need of Redis for Celery, the tests fails without Redis. After inspecting the code, it looks like it's still needed for e.g. session management.

[1] https://github.com/npm/cli/issues/8541
[2] https://next.goauthentik.io/releases/2025.8/#fixed-in-202581