### PR TITLE
frontend: shrink derivation size by removing .map files

### DIFF
--- a/components/frontend.nix
+++ b/components/frontend.nix
@@ -51,6 +51,8 @@ buildNpmPackage {
     mv dist $out/dist
     cp -r authentik icons $out
 
+    find $out/dist/ -name "*.map" -delete
+
     runHook postInstall
   '';
 }


### PR DESCRIPTION
Before: 126MB
After: 72MB